### PR TITLE
Add version and fix link to docs. Solves #3

### DIFF
--- a/owlet/manifest.json
+++ b/owlet/manifest.json
@@ -2,8 +2,9 @@
   "domain": "owlet",
   "name": "Owlet",
   "config_flow": false,
-  "documentation": "https://github.com/CAB426/pyowlet",
+  "documentation": "https://github.com/CAB426/HomeAssistant-Owlet",
   "dependencies": [],
   "codeowners": ["@CAB426"],
+  "version": "v1.0.0",
   "requirements": ["owletpy==1.0.14"]
 }


### PR DESCRIPTION
A breaking change on the latest version (described [here](https://github.com/home-assistant/core/pull/49916)) makes it so this custom component is not recognized. This fixes it.